### PR TITLE
Update standards.md

### DIFF
--- a/charter/standards.md
+++ b/charter/standards.md
@@ -2,7 +2,7 @@
 
 ODI materials and assets are open by default.
 
-ODI shall adopt and utilise Open Standards and/or Open Source License (MIT, Apache, BSD, and **not** GPL) wherever possible and practical. Creative Commons "Attribution, Share-alike" is  default.
+ODI shall adopt and utilise Open Standards and/or Open Source Licences (favouring MIT, Apache and BSD over GPL) wherever possible and practical. Creative Commons "Attribution, Share-alike" is  default.
 
 Any data released by ODI shall use Open Data Certificates.
 


### PR DESCRIPTION
When probing this clause further, the new terminology chosen by @agentGav was to "favour" non-copyleft licences, rather than the hard-line bold language here (see https://github.com/theodi/ODI/issues/11 ) so this change seems an appropriate update.